### PR TITLE
add feature to extract a heading with all of its sub-heading included

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This [Obsidian.md](https://obsidian.md) plugin fixes some problems of the core [
 - [Heading/block links are not updated properly](https://forum.obsidian.md/t/note-composer-links-to-blocks-and-headers-should-be-updated-when-extracting/37534)
 - Cannot undo extraction in the destination file
 
-Currently, it only supports extraction of the current selection or heading.
+Currently, it only supports extraction of the current selection or heading (with and without extracting sub-headings).
 Use the core plugin for merging notes.
 
 ## Installation

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "better-note-composer",
     "name": "Better Note Composer",
-    "version": "0.1.3",
+    "version": "0.2.0",
     "minAppVersion": "1.3.5",
     "description": "",
     "author": "Ryota Ushio",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "better-note-composer",
     "name": "Better Note Composer",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "minAppVersion": "1.3.5",
     "description": "",
     "author": "Ryota Ushio",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "better-note-composer",
     "name": "Better Note Composer",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "minAppVersion": "1.3.5",
     "description": "",
     "author": "Ryota Ushio",

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -230,10 +230,24 @@ export class ExtractionTask extends BetterNoteComposerComponent {
         };
 
         let replacement = '';
+        const heading = cache.headings?.find((heading) => contains(this.extraction.srcRange, heading.position));
+        
         const option = this.plugin.getReplacementText();
         if (option !== 'none') {
-            const linkToExtraction = this.app.fileManager.generateMarkdownLink(this.extraction.dstFile, sourcePath);
+            let subpath = '';
+            if (heading && this.plugin.getLinkToDestHeading()) {
+                subpath = '#' + heading.heading;
+            }
+            const linkToExtraction = this.app.fileManager.generateMarkdownLink(this.extraction.dstFile, sourcePath, subpath);
             replacement = option === 'link' ? linkToExtraction : '!' + linkToExtraction;
+        }
+
+        const keepHeading = this.plugin.getKeepHeading();
+        if (keepHeading) {
+            if (heading) {
+                const headingText = "#".repeat(heading.level) + ' ' + heading.heading;
+                replacement = headingText + '\n\n' + replacement;
+            }
         }
 
         const replaceSrcRangeTransactionSpec: TransactionSpec = {

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -373,6 +373,9 @@ export class ExtractionTask extends BetterNoteComposerComponent {
                 return data;
             });
         }
-        await leaf.openFile(this.extraction.srcRange.file);
+
+        if (this.plugin.getStayOnSourceFile()) {
+            await leaf.openFile(this.extraction.srcRange.file);
+        }
     }
 }

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -373,5 +373,6 @@ export class ExtractionTask extends BetterNoteComposerComponent {
                 return data;
             });
         }
+        await leaf.openFile(this.extraction.srcRange.file);
     }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -108,4 +108,8 @@ export default class BetterNoteComposerPlugin extends Plugin {
 	getLinkToDestHeading(): boolean {
 		return this.settings.linkToDestHeading;
 	}
+
+	getUseHeadingAsAlias(): boolean {
+		return this.settings.useHeadingAsAlias;
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -100,4 +100,12 @@ export default class BetterNoteComposerPlugin extends Plugin {
 	getStayOnSourceFile(): boolean {
 		return this.settings.stayOnSourceFile;
 	}
+
+	getKeepHeading(): boolean {
+		return this.settings.keepHeading;
+	}
+
+	getLinkToDestHeading(): boolean {
+		return this.settings.linkToDestHeading;
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -96,4 +96,8 @@ export default class BetterNoteComposerPlugin extends Plugin {
 			? (this.app.internalPlugins.plugins['note-composer'].instance.options.replacementText ?? 'link')
 			: this.settings.replacementText;
 	}
+
+	getStayOnSourceFile(): boolean {
+		return this.settings.stayOnSourceFile;
+	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@ import { Extractor } from 'extract';
 import { MarkdownFileChooserModal } from 'modals';
 import { BetterNoteComposerEditorCommand } from 'commands';
 import { BetterNoteComposerSettings, DEFAULT_SETTINGS, BetterNoteComposerSettingTab } from 'settings';
-
+import { isHeading } from 'utils';
 
 export default class BetterNoteComposerPlugin extends Plugin {
 	settings: BetterNoteComposerSettings;
@@ -60,6 +60,25 @@ export default class BetterNoteComposerPlugin extends Plugin {
 					const srcFile = info.file!;
 					showModalAndRun(srcFile, (dstFile, evt) => {
 						this.extractor.extractHeading(srcFile, editor, dstFile, Keymap.isModEvent(evt))
+					});
+				}
+			}),
+			new BetterNoteComposerEditorCommand({
+				id: 'extract-heading-recursive',
+				name: 'Extract this heading recursively...',
+				checker: (editor, info) => {
+					// @ts-ignore
+					const cm: EditorView = editor.cm;
+			        const currentLine = cm.state.doc.lineAt(cm.state.selection.main.anchor);
+					let currentHeadingLine = cm.state.doc.line(currentLine.number);
+
+					// Must click on the heading line to avoid matching with comments in a code block
+					return !!info.file && isHeading(currentHeadingLine.text);
+				},
+				executor: (editor, info) => {
+					const srcFile = info.file!;
+					showModalAndRun(srcFile, (dstFile, evt) => {
+						this.extractor.extractHeadingRecursive(srcFile, editor, dstFile, Keymap.isModEvent(evt))
 					});
 				}
 			}),

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,10 +11,12 @@ const REPLACEMENT_TEXT = {
 
 export interface BetterNoteComposerSettings {
 	replacementText: keyof typeof REPLACEMENT_TEXT;
+	stayOnSourceFile: boolean;
 }
 
 export const DEFAULT_SETTINGS: BetterNoteComposerSettings = {
 	replacementText: 'same',
+	stayOnSourceFile: true,
 };
 
 export class BetterNoteComposerSettingTab extends PluginSettingTab {
@@ -33,6 +35,17 @@ export class BetterNoteComposerSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.replacementText)
 					.onChange(async (value: keyof typeof REPLACEMENT_TEXT) => {
 						this.plugin.settings.replacementText = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(this.containerEl)
+			.setName('Stay on source file')
+			.setDesc('Stay on the source file after extraction.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.stayOnSourceFile)
+					.onChange(async (value) => {
+						this.plugin.settings.stayOnSourceFile = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,11 +12,15 @@ const REPLACEMENT_TEXT = {
 export interface BetterNoteComposerSettings {
 	replacementText: keyof typeof REPLACEMENT_TEXT;
 	stayOnSourceFile: boolean;
+	keepHeading: boolean;
+	linkToDestHeading: boolean;
 }
 
 export const DEFAULT_SETTINGS: BetterNoteComposerSettings = {
 	replacementText: 'same',
 	stayOnSourceFile: true,
+	keepHeading: true,
+	linkToDestHeading: true,
 };
 
 export class BetterNoteComposerSettingTab extends PluginSettingTab {
@@ -46,6 +50,28 @@ export class BetterNoteComposerSettingTab extends PluginSettingTab {
 				toggle.setValue(this.plugin.settings.stayOnSourceFile)
 					.onChange(async (value) => {
 						this.plugin.settings.stayOnSourceFile = value;
+						await this.plugin.saveSettings();
+					});
+			});
+			
+		new Setting(this.containerEl)
+			.setName('Keep heading')
+			.setDesc('Keep the heading of the source file after extraction.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.keepHeading)
+					.onChange(async (value) => {
+						this.plugin.settings.keepHeading = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(this.containerEl)
+			.setName('Link to destination heading')
+			.setDesc('Link to the destination heading after extraction if using the "Link" option.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.linkToDestHeading)
+					.onChange(async (value) => {
+						this.plugin.settings.linkToDestHeading = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -14,6 +14,7 @@ export interface BetterNoteComposerSettings {
 	stayOnSourceFile: boolean;
 	keepHeading: boolean;
 	linkToDestHeading: boolean;
+	useHeadingAsAlias: boolean;
 }
 
 export const DEFAULT_SETTINGS: BetterNoteComposerSettings = {
@@ -21,6 +22,7 @@ export const DEFAULT_SETTINGS: BetterNoteComposerSettings = {
 	stayOnSourceFile: true,
 	keepHeading: true,
 	linkToDestHeading: true,
+	useHeadingAsAlias: true,
 };
 
 export class BetterNoteComposerSettingTab extends PluginSettingTab {
@@ -72,6 +74,17 @@ export class BetterNoteComposerSettingTab extends PluginSettingTab {
 				toggle.setValue(this.plugin.settings.linkToDestHeading)
 					.onChange(async (value) => {
 						this.plugin.settings.linkToDestHeading = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(this.containerEl)
+			.setName('Use heading as alias')
+			.setDesc('Use the heading as the alias if using the "Link" option.')
+			.addToggle((toggle) => {
+				toggle.setValue(this.plugin.settings.useHeadingAsAlias)
+					.onChange(async (value) => {
+						this.plugin.settings.useHeadingAsAlias = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,10 @@ export function isHeading(line: string) {
     return /^#{1,6} /.test(line);
 }
 
+export function getHeadingLevel(line: string) {
+    return line.match(/^(#{1,6}) /)?.[1].length ?? 0;
+}
+
 export function offsetToLoc(editor: Editor, offset: number): Loc {
     const pos = editor.offsetToPos(offset);
     return { line: pos.line, col: pos.ch, offset };


### PR DESCRIPTION
I added a function to support extracting heading and sub-headings. User must click on a heading to use it to avoid unintentionally matching with comments inside code block.